### PR TITLE
docs: fixed typo in vercel preset

### DIFF
--- a/docs/content/2.deploy/providers/vercel.md
+++ b/docs/content/2.deploy/providers/vercel.md
@@ -23,7 +23,7 @@ Learn more about Vercel’s [Git Integration](https://vercel.com/docs/concepts/g
 
 ## Vercel Edge Functions
 
-**Preset:** `vercel_edge` ([switch to this preset](/deploy/#changing-the-deployment-preset))
+**Preset:** `vercel-edge` ([switch to this preset](/deploy/#changing-the-deployment-preset))
 
 It is possible to deploy your nitro applications directly on [Vercel Edge Functions](https://vercel.com/docs/concepts/functions/edge-functions).
 
@@ -33,7 +33,7 @@ It is possible to deploy your nitro applications directly on [Vercel Edge Functi
 > By taking advantage of this small runtime, Edge Functions can have faster cold boots and higher scalability than Serverless Functions.
 > Edge Functions run after the cache, and can both cache and return responses. [Read More](https://vercel.com/docs/concepts/functions/edge-functions)
 
-In order to enable this target, please set `NITRO_PRESET` environment variable to `vercel_edge`.
+In order to enable this target, please set `NITRO_PRESET` environment variable to `vercel-edge`.
 
 ## Vercel KV Storage
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->


### 📚 Description

Pretty sure thats a typo and it should be `vercel-edge` rather than `vercel_edge`.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->


### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
